### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Overview:
 # This pyproject.toml file manages the build, packaging, and distribution of the Ultralytics Template library.


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Minor formatting updates to improve code consistency and readability.  

### 📊 Key Changes  
- Adjusted comment formatting in `.github/workflows/format.yml` and `pyproject.toml` to standardize the license text.  
  - Changed from: `License https://ultralytics.com/license`  
  - To: `License - https://ultralytics.com/license`.  

### 🎯 Purpose & Impact  
- 🛠 **Improved Consistency**: Ensures comments use a uniform format across files for better clarity.  
- ✨ **Code Quality**: Makes the project documentation more professional and easier to maintain.  
- 🔍 **No Functional Changes**: These updates are purely cosmetic and have no direct impact on end-users or functionality.