### PR TITLE
Update `SAM2` notebook

### DIFF
--- a/notebooks/inference-with-meta-sam-and-sam2-using-ultralytics-python-package.ipynb
+++ b/notebooks/inference-with-meta-sam-and-sam2-using-ultralytics-python-package.ipynb
@@ -26,7 +26,7 @@
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",
         "\n",
         "  <a href=\"https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml\"><img src=\"https://github.com/ultralytics/ultralytics/actions/workflows/ci.yml/badge.svg\" alt=\"Ultralytics CI\"></a>\n",
-        "  <a href=\"https://colab.research.google.com/github/ultralytics/notebooks/blob/main/notebooks/how-to-train-ultralytics-yolo-on-carparts-segmentation-dataset.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>\n",
+        "  <a href=\"https://colab.research.google.com/github/ultralytics/notebooks/blob/main/notebooks/inference-with-meta-sam-and-sam2-using-ultralytics-python-package.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"></a>\n",
         "\n",
         "\n",
         "  <a href=\"https://ultralytics.com/discord\"><img alt=\"Discord\" src=\"https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue\"></a>\n",


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated the Colab link in the notebook to point to the correct file for inference with Meta SAM and SAM2 using the Ultralytics Python package.  

### 📊 Key Changes  
- 🔗 Fixed the Colab link in the notebook's header to correctly reference the current notebook (`inference-with-meta-sam-and-sam2-using-ultralytics-python-package.ipynb`).  

### 🎯 Purpose & Impact  
- ✅ Ensures users are directed to the correct Colab notebook for running inference with Meta SAM and SAM2, improving usability and reducing confusion.  
- 🚀 Enhances the user experience by providing a seamless and accurate link for quick access to the notebook.