### PR TITLE
Remove `uv` from notebooks

### DIFF
--- a/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
@@ -76,7 +76,7 @@
         "id": "wbvMlHd_QwMG"
       },
       "source": [
-        "!uv pip install ultralytics\n",
+        "!pip install ultralytics\n",
         "\n",
         "import ultralytics\n",
         "import cv2\n",

--- a/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
@@ -78,7 +78,7 @@
     }
    ],
    "source": [
-    "!uv pip install ultralytics\n",
+    "!pip install ultralytics\n",
     "\n",
     "import cv2\n",
     "import ultralytics\n",

--- a/notebooks/how-to-monitor-workouts-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-monitor-workouts-using-ultralytics-yolo.ipynb
@@ -80,7 +80,7 @@
     }
    ],
    "source": [
-    "!uv pip install ultralytics\n",
+    "!pip install ultralytics\n",
     "\n",
     "import cv2\n",
     "import ultralytics\n",

--- a/notebooks/how-to-track-the-objects-in-zone-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-track-the-objects-in-zone-using-ultralytics-yolo.ipynb
@@ -77,7 +77,7 @@
         "id": "wbvMlHd_QwMG"
       },
       "source": [
-        "!uv pip install ultralytics\n",
+        "!pip install ultralytics\n",
         "\n",
         "import ultralytics\n",
         "import cv2\n",

--- a/notebooks/how-to-train-ultralytics-yolo-on-brain-tumor-detection-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-brain-tumor-detection-dataset.ipynb
@@ -96,7 +96,7 @@
         "outputId": "2e1e3635-7e3c-404d-8f28-dd15f6b1bea3"
       },
       "source": [
-        "!uv pip install ultralytics\n",
+        "!pip install ultralytics\n",
         "import ultralytics\n",
         "ultralytics.checks()"
       ],

--- a/notebooks/how-to-train-ultralytics-yolo-on-carparts-segmentation-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-carparts-segmentation-dataset.ipynb
@@ -92,7 +92,7 @@
         "id": "wbvMlHd_QwMG"
       },
       "source": [
-        "!uv pip install ultralytics\n",
+        "!pip install ultralytics\n",
         "import ultralytics\n",
         "ultralytics.checks()"
       ],

--- a/notebooks/how-to-train-ultralytics-yolo-on-crack-segmentation-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-crack-segmentation-dataset.ipynb
@@ -95,7 +95,7 @@
         "id": "wbvMlHd_QwMG"
       },
       "source": [
-        "!uv pip install ultralytics\n",
+        "!pip install ultralytics\n",
         "import ultralytics\n",
         "ultralytics.checks()"
       ],

--- a/notebooks/how-to-train-ultralytics-yolo-on-medical-pills-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-medical-pills-dataset.ipynb
@@ -98,7 +98,7 @@
         "outputId": "dc288ecf-d09d-4a22-8b37-7169b5a56e37"
       },
       "source": [
-        "!uv pip install ultralytics\n",
+        "!pip install ultralytics\n",
         "import ultralytics\n",
         "ultralytics.checks()"
       ],

--- a/notebooks/how-to-train-ultralytics-yolo-on-package-segmentation-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-package-segmentation-dataset.ipynb
@@ -93,7 +93,7 @@
         "id": "wbvMlHd_QwMG"
       },
       "source": [
-        "!uv pip install ultralytics\n",
+        "!pip install ultralytics\n",
         "import ultralytics\n",
         "ultralytics.checks()"
       ],

--- a/notebooks/how-to-use-florence-2-for-object-detection-image-captioning-ocr-and-segmentation.ipynb
+++ b/notebooks/how-to-use-florence-2-for-object-detection-image-captioning-ocr-and-segmentation.ipynb
@@ -78,7 +78,7 @@
     }
    ],
    "source": [
-    "!uv pip install transformers==4.49.0 ultralytics\n",
+    "!pip install transformers==4.49.0 ultralytics\n",
     "\n",
     "import cv2\n",
     "import numpy as np\n",

--- a/notebooks/how-to-use-google-gemini-models-for-object-detection-image-captioning-and-ocr.ipynb
+++ b/notebooks/how-to-use-google-gemini-models-for-object-detection-image-captioning-and-ocr.ipynb
@@ -92,7 +92,7 @@
     }
    ],
    "source": [
-    "!uv pip install -U -q google-genai ultralytics\n",
+    "!pip install -U -q google-genai ultralytics\n",
     "\n",
     "import json\n",
     "\n",

--- a/notebooks/how-to-use-ultralytics-yolo-with-openai-for-number-plate-recognition.ipynb
+++ b/notebooks/how-to-use-ultralytics-yolo-with-openai-for-number-plate-recognition.ipynb
@@ -79,7 +79,7 @@
     }
    ],
    "source": [
-    "!uv pip install ultralytics\n",
+    "!pip install ultralytics\n",
     "\n",
     "import base64\n",
     "\n",

--- a/notebooks/how-to-use-ultralytics-yolo-with-sahi.ipynb
+++ b/notebooks/how-to-use-ultralytics-yolo-with-sahi.ipynb
@@ -81,7 +81,7 @@
         }
       },
       "source": [
-        "!uv pip install ultralytics sahi\n",
+        "!pip install ultralytics sahi\n",
         "import ultralytics\n",
         "from ultralytics.utils.downloads import safe_download\n",
         "ultralytics.checks()"

--- a/notebooks/inference-with-meta-sam-and-sam2-using-ultralytics-python-package.ipynb
+++ b/notebooks/inference-with-meta-sam-and-sam2-using-ultralytics-python-package.ipynb
@@ -94,7 +94,7 @@
         "outputId": "45361f29-2899-4751-aed8-aca158d314ba"
       },
       "source": [
-        "!uv pip install ultralytics\n",
+        "!pip install ultralytics\n",
         "import ultralytics\n",
         "ultralytics.checks()"
       ],


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated multiple Jupyter notebooks to simplify the installation command for the Ultralytics package.

### 📊 Key Changes  
- Replaced `!uv pip install ultralytics` with the standard `!pip install ultralytics` across all notebooks.  
- Adjusted similar commands in notebooks using additional dependencies (e.g., `transformers`, `sahi`, `google-genai`) for consistency.

### 🎯 Purpose & Impact  
- **Purpose**: Simplify and standardize installation commands, removing the `uv` alias for better clarity and compatibility.  
- **Impact**:  
  - Enhances user experience by aligning with standard Python practices.  
  - Reduces potential confusion for new users unfamiliar with the `uv` alias.  
  - Ensures broader compatibility across environments where the alias might not be recognized. 🚀