### PR TITLE
Remove `cv2.destroyAllWindows()` from notebooks

### DIFF
--- a/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
@@ -199,7 +199,7 @@
         "    video_writer.write(results.plot_im)   # write the video frames\n",
         "\n",
         "cap.release()   # Release the capture\n",
-        "video_writer.release()\n",
+        "video_writer.release()",
       ],
       "metadata": {
         "id": "PVf1pyRtXijz"

--- a/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
@@ -200,7 +200,6 @@
         "\n",
         "cap.release()   # Release the capture\n",
         "video_writer.release()\n",
-        "cv2.destroyAllWindows()"
       ],
       "metadata": {
         "id": "PVf1pyRtXijz"

--- a/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
@@ -199,7 +199,7 @@
         "    video_writer.write(results.plot_im)   # write the video frames\n",
         "\n",
         "cap.release()   # Release the capture\n",
-        "video_writer.release()",
+        "video_writer.release()"
       ],
       "metadata": {
         "id": "PVf1pyRtXijz"

--- a/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
@@ -200,7 +200,7 @@
     "    video_writer.write(results.plot_im)  # write the video frame\n",
     "\n",
     "cap.release()\n",
-    "video_writer.release()  # release the video_writer\n",
+    "video_writer.release()  # release the video_writer",
    ]
   },
   {

--- a/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
@@ -200,7 +200,7 @@
     "    video_writer.write(results.plot_im)  # write the video frame\n",
     "\n",
     "cap.release()\n",
-    "video_writer.release()  # release the video_writer",
+    "video_writer.release()  # release the video_writer\n"
    ]
   },
   {

--- a/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
@@ -201,7 +201,6 @@
     "\n",
     "cap.release()\n",
     "video_writer.release()  # release the video_writer\n",
-    "cv2.destroyAllWindows()"
    ]
   },
   {

--- a/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
@@ -200,7 +200,7 @@
     "    video_writer.write(results.plot_im)  # write the video frame\n",
     "\n",
     "cap.release()\n",
-    "video_writer.release()  # release the video_writer\n"
+    "video_writer.release()  # release the video_writer"
    ]
   },
   {

--- a/notebooks/how-to-monitor-workouts-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-monitor-workouts-using-ultralytics-yolo.ipynb
@@ -261,7 +261,6 @@
     "    results = gym(im0)  # monitor workouts on each frame\n",
     "    video_writer.write(results.plot_im)  # write the output frame in file.\n",
     "\n",
-    "cv2.destroyAllWindows()\n",
     "video_writer.release()"
    ]
   },
@@ -319,7 +318,6 @@
     "    results = gym(im0)  # monitor workouts on each frame\n",
     "    video_writer.write(results.plot_im)  # write the output frame in file.\n",
     "\n",
-    "cv2.destroyAllWindows()\n",
     "video_writer.release()"
    ]
   },
@@ -379,7 +377,6 @@
     "    results = gym(im0)  # monitor workouts on each frame\n",
     "    video_writer.write(results.plot_im)  # write the output frame in file.\n",
     "\n",
-    "cv2.destroyAllWindows()\n",
     "video_writer.release()"
    ]
   },
@@ -437,7 +434,6 @@
     "    results = gym(im0)  # monitor workouts on each frame\n",
     "    video_writer.write(results.plot_im)  # write the output frame in file.\n",
     "\n",
-    "cv2.destroyAllWindows()\n",
     "video_writer.release()"
    ]
   },

--- a/notebooks/how-to-track-the-objects-in-zone-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-track-the-objects-in-zone-using-ultralytics-yolo.ipynb
@@ -198,8 +198,7 @@
         "    video_writer.write(results.plot_im)   # write the video frames\n",
         "\n",
         "cap.release()   # Release the capture\n",
-        "video_writer.release()\n",
-        "cv2.destroyAllWindows()"
+        "video_writer.release()"
       ],
       "metadata": {
         "id": "PVf1pyRtXijz"


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR removes unnecessary `cv2.destroyAllWindows()` calls from several Ultralytics YOLO tutorial notebooks for cleaner and more robust code. 🧹✨

### 📊 Key Changes
- Deleted all instances of `cv2.destroyAllWindows()` from the following notebooks:
  - How to Count the Objects Using Ultralytics YOLO
  - How to Generate Heatmaps Using Ultralytics YOLO
  - How to Monitor Workouts Using Ultralytics YOLO
  - How to Track the Objects in Zone Using Ultralytics YOLO

### 🎯 Purpose & Impact
- Prevents potential errors in headless or non-GUI environments (e.g., cloud, servers, Colab) where window management is not needed.
- Simplifies the code, making the notebooks easier to run and understand for all users.
- Improves compatibility and reliability across different platforms and setups. 🚀