### PR TITLE
Add sample videos to test notebooks quickly

### DIFF
--- a/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
@@ -80,6 +80,7 @@
         "\n",
         "import ultralytics\n",
         "import cv2\n",
+        "from ultralytics.utils.downloads import safe_download\n",
         "from ultralytics import solutions\n",
         "\n",
         "ultralytics.checks()"
@@ -102,7 +103,8 @@
     {
       "cell_type": "code",
       "source": [
-        "cap = cv2.VideoCapture(\"path/to/video/file.mp4\")\n",
+        "safe_download(f"{url}/solutions-ci-demo.mp4")\n"
+        "cap = cv2.VideoCapture(\"/content/solutions-ci-demo.mp4\")\n",
         "assert cap.isOpened(), \"Error reading video file\"\n",
         "w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH,\n",
         "                                       cv2.CAP_PROP_FRAME_HEIGHT,\n",

--- a/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
@@ -103,7 +103,7 @@
     {
       "cell_type": "code",
       "source": [
-        "safe_download(f"{url}/solutions-ci-demo.mp4")\n"
+        "safe_download(\f"{url}/solutions-ci-demo.mp4\")\n"
         "cap = cv2.VideoCapture(\"/content/solutions-ci-demo.mp4\")\n",
         "assert cap.isOpened(), \"Error reading video file\"\n",
         "w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH,\n",

--- a/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
@@ -103,8 +103,7 @@
     {
       "cell_type": "code",
       "source": [
-        "safe_download(f\"{url}/solutions-ci-demo.mp4\")\n"
-        "cap = cv2.VideoCapture(\"/content/solutions-ci-demo.mp4\")\n",
+        "cap = cv2.VideoCapture(\"path/to/video/file.mp4\")\n",
         "assert cap.isOpened(), \"Error reading video file\"\n",
         "w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH,\n",
         "                                       cv2.CAP_PROP_FRAME_HEIGHT,\n",

--- a/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
@@ -104,6 +104,8 @@
       "cell_type": "code",
       "source": [
         "cap = cv2.VideoCapture(\"path/to/video/file.mp4\")\n",
+        "cap = cv2.VideoCapture(\"/content/solutions-ci-demo.mp4\")\n",
+        
         "assert cap.isOpened(), \"Error reading video file\"\n",
         "w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH,\n",
         "                                       cv2.CAP_PROP_FRAME_HEIGHT,\n",

--- a/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
@@ -103,7 +103,7 @@
     {
       "cell_type": "code",
       "source": [
-        "cap = cv2.VideoCapture(\"path/to/video/file.mp4\")\n",
+        "safe_download(f\"{url}/solutions-ci-demo.mp4\")\n",
         "cap = cv2.VideoCapture(\"/content/solutions-ci-demo.mp4\")\n",
         
         "assert cap.isOpened(), \"Error reading video file\"\n",

--- a/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
@@ -103,9 +103,9 @@
     {
       "cell_type": "code",
       "source": [
-        "safe_download(f\"{url}/solutions-ci-demo.mp4\")\n",
+        "safe_download(\"https://github.com/ultralytics/notebooks/releases/download/v0.0.0/solutions-ci-demo.mp4\")\n",
         "cap = cv2.VideoCapture(\"/content/solutions-ci-demo.mp4\")\n",
-        
+
         "assert cap.isOpened(), \"Error reading video file\"\n",
         "w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH,\n",
         "                                       cv2.CAP_PROP_FRAME_HEIGHT,\n",

--- a/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
@@ -103,7 +103,7 @@
     {
       "cell_type": "code",
       "source": [
-        "safe_download(\f"{url}/solutions-ci-demo.mp4\")\n"
+        "safe_download(f\"{url}/solutions-ci-demo.mp4\")\n"
         "cap = cv2.VideoCapture(\"/content/solutions-ci-demo.mp4\")\n",
         "assert cap.isOpened(), \"Error reading video file\"\n",
         "w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH,\n",

--- a/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
@@ -109,6 +109,7 @@
    "source": [
     "safe_download(\"https://github.com/ultralytics/notebooks/releases/download/v0.0.0/solutions-ci-demo.mp4\")\n",
     "cap = cv2.VideoCapture(\"/content/solutions-ci-demo.mp4\")\n",
+
     "assert cap.isOpened(), \"Error reading video file\"\n",
     "w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH, cv2.CAP_PROP_FRAME_HEIGHT, cv2.CAP_PROP_FPS))\n",
     "\n",

--- a/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
@@ -82,8 +82,8 @@
     "\n",
     "import cv2\n",
     "import ultralytics\n",
-    "from ultralytics.utils.downloads import safe_download\n",
     "from ultralytics import solutions\n",
+    "from ultralytics.utils.downloads import safe_download\n",
     "\n",
     "ultralytics.checks()"
    ]
@@ -109,7 +109,6 @@
    "source": [
     "safe_download(\"https://github.com/ultralytics/notebooks/releases/download/v0.0.0/solutions-ci-demo.mp4\")\n",
     "cap = cv2.VideoCapture(\"/content/solutions-ci-demo.mp4\")\n",
-    
     "assert cap.isOpened(), \"Error reading video file\"\n",
     "w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH, cv2.CAP_PROP_FRAME_HEIGHT, cv2.CAP_PROP_FPS))\n",
     "\n",
@@ -215,7 +214,7 @@
     "![Ultralytics YOLO11 Retail Heatmap](https://github.com/ultralytics/docs/releases/download/0/ultralytics-yolov8-retail-heatmap.avif)"
    ]
   },
-{
+  {
    "cell_type": "markdown",
    "metadata": {
     "id": "bwBUa5kZyZ2k"

--- a/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
@@ -82,6 +82,7 @@
     "\n",
     "import cv2\n",
     "import ultralytics\n",
+    "from ultralytics.utils.downloads import safe_download\n",
     "from ultralytics import solutions\n",
     "\n",
     "ultralytics.checks()"
@@ -106,7 +107,9 @@
    },
    "outputs": [],
    "source": [
-    "cap = cv2.VideoCapture(\"Path/to/video/file.mp4\")\n",
+    "safe_download(\"https://github.com/ultralytics/notebooks/releases/download/v0.0.0/solutions-ci-demo.mp4\")\n",
+    "cap = cv2.VideoCapture(\"/content/solutions-ci-demo.mp4\")\n",
+    
     "assert cap.isOpened(), \"Error reading video file\"\n",
     "w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH, cv2.CAP_PROP_FRAME_HEIGHT, cv2.CAP_PROP_FPS))\n",
     "\n",

--- a/notebooks/how-to-track-the-objects-in-zone-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-track-the-objects-in-zone-using-ultralytics-yolo.ipynb
@@ -81,7 +81,7 @@
         "\n",
         "import ultralytics\n",
         "import cv2\n",
-        "from ultralytics.utils.download import safe_download\n",
+        "from ultralytics.utils.downloads import safe_download\n",
         "from ultralytics import solutions\n",
         "\n",
         "ultralytics.checks()"

--- a/notebooks/how-to-track-the-objects-in-zone-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-track-the-objects-in-zone-using-ultralytics-yolo.ipynb
@@ -81,6 +81,7 @@
         "\n",
         "import ultralytics\n",
         "import cv2\n",
+        "from ultralytics.utils.download import safe_download\n",
         "from ultralytics import solutions\n",
         "\n",
         "ultralytics.checks()"
@@ -103,7 +104,9 @@
     {
       "cell_type": "code",
       "source": [
-        "cap = cv2.VideoCapture(\"path/to/video/file.mp4\")\n",
+        "safe_download(\"https://github.com/ultralytics/notebooks/releases/download/v0.0.0/solutions-ci-demo.mp4\")\n",
+        "cap = cv2.VideoCapture(\"/content/solutions-ci-demo.mp4\")\n",
+        
         "assert cap.isOpened(), \"Error reading video file\"\n",
         "w, h, fps = (int(cap.get(x)) for x in (cv2.CAP_PROP_FRAME_WIDTH,\n",
         "                                       cv2.CAP_PROP_FRAME_HEIGHT,\n",


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Sample video downloads are now automated in Ultralytics YOLO tutorial notebooks, making it easier for users to get started. 📹✨

### 📊 Key Changes
- Added automatic downloading of a sample video file (`solutions-ci-demo.mp4`) in three tutorial notebooks:
  - Object counting
  - Heatmap generation
  - Object tracking in zones
- Replaced placeholder video paths with code that downloads and loads the sample video using `safe_download`.

### 🎯 Purpose & Impact
- 🛠️ Simplifies setup: Users no longer need to manually provide or download a video file to run the tutorials.
- 🚀 Faster onboarding: New users can immediately run the notebooks without extra steps, improving the learning experience.
- 📚 Consistent demos: Ensures everyone uses the same sample video, making results easier to follow and reproduce.