### PR TITLE
Bump actions/setup-python from v4 to v6 in /.github/workflows/table.yml

### DIFF
--- a/.github/workflows/table.yml
+++ b/.github/workflows/table.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - run: pip install pyyaml


### PR DESCRIPTION
Bump actions/setup-python from v4 to v6 in /.github/workflows/table.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions workflow to use a newer version of `actions/setup-python`, improving CI maintenance and compatibility.

### 📊 Key Changes
- Upgraded the GitHub Actions step in `.github/workflows/table.yml` from `actions/setup-python@v4` to `actions/setup-python@v6` 🚀
- Kept the existing Python setup behavior the same by continuing to use `python-version: "3.x"` ✅
- No notebook code or functionality changes were made 📓

### 🎯 Purpose & Impact
- Improves workflow reliability by using a more current GitHub Action version 🛠️
- Helps keep the repository’s automation up to date with GitHub’s latest improvements and support policies 🔄
- Reduces potential future CI issues related to older action versions ⚡
- Has little to no direct impact on end users, but benefits maintainers through smoother automated checks and easier long-term upkeep 👨‍💻