### PR TITLE
Bump actions/checkout to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/table.yml
+++ b/.github/workflows/table.yml
@@ -17,7 +17,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"


### PR DESCRIPTION
Bump actions/checkout to v6 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).