### PR TITLE
Bump actions/setup-python to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/table.yml
+++ b/.github/workflows/table.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - run: pip install pyyaml


### PR DESCRIPTION
Bump actions/setup-python to v6 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions workflow in `ultralytics/notebooks` to use a newer version of the Python setup action.

### 📊 Key Changes
- ⬆️ Upgraded `.github/workflows/table.yml` from `actions/setup-python@v4` to `actions/setup-python@v6`
- 🛠️ No notebook code or user-facing functionality was changed
- 🤖 The update only affects the repository’s CI/CD automation for setting up Python in GitHub Actions

### 🎯 Purpose & Impact
- ✅ Keeps the project’s GitHub Actions workflow current with the latest supported action version
- 🔒 May improve security, compatibility, and long-term maintenance of automated workflows
- 🚀 Helps reduce the risk of future CI issues caused by outdated GitHub Actions dependencies
- 👥 Minimal direct impact on end users, but beneficial for maintainers and overall repository reliability