### PR TITLE
Bump actions/checkout from v4 to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/table.yml
+++ b/.github/workflows/table.yml
@@ -17,7 +17,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"


### PR DESCRIPTION
Bump actions/checkout from v4 to v6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions checkout step in the notebooks repository from `actions/checkout@v4` to `actions/checkout@v6` to keep the CI workflow current and supported.

### 📊 Key Changes
- Upgraded the `actions/checkout` action in `.github/workflows/table.yml`
- Changed the workflow dependency from `actions/checkout@v4` to `actions/checkout@v6`
- Left the rest of the workflow unchanged, including Python setup and job structure

### 🎯 Purpose & Impact
- Improves workflow maintainability by using a newer GitHub Actions version 🚀
- Helps keep CI automation aligned with current GitHub best practices and updates ✅
- Reduces the risk of relying on older action versions that may become outdated or unsupported over time 🛡️
- Has minimal user-facing impact, but supports more reliable repository automation behind the scenes ⚙️