### PR TITLE
Bump actions/checkout from v4 to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
Bump actions/checkout from v4 to v6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions CI workflow to use `actions/checkout@v6` instead of `actions/checkout@v4` in both workflow jobs.

### 📊 Key Changes
- Updated the **Checkout code** step in `.github/workflows/ci.yml` from `actions/checkout@v4` to `actions/checkout@v6` ✅
- Applied this upgrade consistently across both CI jobs in the workflow 🔧
- No notebook content, training logic, or user-facing examples were changed 📓

### 🎯 Purpose & Impact
- Improves CI maintenance by keeping the repository aligned with newer GitHub Actions versions 🚀
- May provide better reliability, compatibility, and security in automated workflow runs 🔒
- Has **no direct impact** on notebook usage or model behavior for end users 👥
- Helps reduce technical debt and keeps the project’s automation stack up to date 🛠️