### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/table.yml
+++ b/.github/workflows/table.yml
@@ -17,7 +17,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates GitHub Actions workflows to use `actions/checkout@v7` instead of `@v6`, keeping the repository’s CI and automation setup current.

### 📊 Key Changes
- Updated the **checkout step** from `actions/checkout@v6` to `actions/checkout@v7` in `.github/workflows/ci.yml` ✅
- Updated the same **checkout action version** in `.github/workflows/table.yml` 📋
- No notebook content, model logic, or user-facing features were changed 🧩

### 🎯 Purpose & Impact
- Improves **workflow maintenance** by aligning the repo with the latest GitHub Action version 🔧
- Helps ensure **better compatibility and long-term support** for CI and automation pipelines 🛡️
- Reduces the chance of issues caused by relying on older action versions ⏳
- Has **minimal impact for end users**, but benefits contributors and maintainers through a more up-to-date development setup 👨‍💻✨