### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
         with:
           python-version: "3.14"
           activate-environment: true
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
         with:
           python-version: "3.14"
           activate-environment: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ pytest tests/test_notebooks.py::test_export_val_results                 # run on
 python3 docs/update-readme-table.py                                     # regenerate README.md table (needs pyyaml, run from repo root)
 ```
 
-- CI (`.github/workflows/ci.yml`) runs on `ubuntu-latest` with Python 3.14 via `astral-sh/setup-uv` — a single Python version, no matrix, no coverage tooling; PRs run only the fast `notebook-smoke` job.
+- CI (`.github/workflows/ci.yml`) runs on `ubuntu-latest` with Python 3.14 via `ultralytics/actions/setup-uv@main` — a single Python version, no matrix, no coverage tooling; PRs run only the fast `notebook-smoke` job.
 - There is no local lint config (no pyproject/ruff/prettier files); formatting is applied in PRs by the Ultralytics Actions bot (`.github/workflows/format.yml`: Ruff, docformatter, Prettier, codespell).
 
 ## Architecture


### PR DESCRIPTION
## Summary
- replace both Astral uv setup steps with the shared retried owner
- preserve the existing Python 3.14 and environment activation inputs
- update the CI owner documented in AGENTS.md

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer owner.

Deleted: 2 direct astral-sh/setup-uv dependencies and 1 stale AGENTS.md reference to the original action.

## Validation
- zero astral-sh/setup-uv occurrences
- both setup callers are exactly ultralytics/actions/setup-uv@main
- actionlint .github/workflows/ci.yml
- git diff --check
- shared owner passed cache-enabled Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔧 Updated notebook CI to use Ultralytics’ centralized `setup-uv` action.

### 📊 Key Changes

- Replaced `astral-sh/setup-uv@v7` with `ultralytics/actions/setup-uv@main` in both CI jobs.
- Updated `AGENTS.md` to document the new CI setup and action source.
- Kept the existing Python 3.14 environment and notebook smoke-test workflow unchanged.

### 🎯 Purpose & Impact

- ✅ Centralizes dependency and environment setup across Ultralytics repositories.
- 🚀 May improve consistency, maintainability, and future CI updates.
- 🧪 Notebook validation behavior remains unchanged, so contributors should see no difference in test coverage or workflow scope.