### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/table.yml
+++ b/.github/workflows/table.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - run: pip install pyyaml


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
⬆️ Updates the GitHub Actions Python setup to `actions/setup-python@v7` for automated table generation.

### 📊 Key Changes
- Replaces `actions/setup-python@v6` with `actions/setup-python@v7` in `.github/workflows/table.yml`.
- Keeps the workflow on the latest available Python 3.x version.
- Leaves the existing `pyyaml` installation and other workflow steps unchanged.

### 🎯 Purpose & Impact
- ✅ Keeps the CI workflow aligned with the current `setup-python` action release.
- 🔧 May improve reliability, compatibility, and maintenance of automated notebook table updates.
- 🚀 No changes to notebooks or user-facing functionality are expected.