### PR TITLE
Point banner link to YOLO Vision 2026 registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
  <p>	
-    <a href="https://platform.ultralytics.com/ultralytics/yolo26" target="_blank">
+    <a href="https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner" target="_blank">
       <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>	
   </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
  <p>	
-    <a href="https://platform.ultralytics.com/ultralytics/yolo26" target="_blank">
+    <a href="https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner" target="_blank">
       <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>	
   </p>
 

--- a/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-count-the-objects-using-ultralytics-yolo.ipynb
@@ -21,7 +21,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-export-the-validation-results-into-dataframe-csv-sql-and-other-formats.ipynb
+++ b/notebooks/how-to-export-the-validation-results-into-dataframe-csv-sql-and-other-formats.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-generate-heatmaps-using-ultralytics-yolo.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "<div align=\"center\">\n",
     "\n",
-    "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+    "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
     "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
     "\n",
     "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-monitor-objects-in-queue-using-queue-management-solution.ipynb
+++ b/notebooks/how-to-monitor-objects-in-queue-using-queue-management-solution.ipynb
@@ -20,7 +20,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-monitor-workouts-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-monitor-workouts-using-ultralytics-yolo.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "<div align=\"center\">\n",
     "\n",
-    "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+    "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
     "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
     "\n",
     "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-track-the-objects-in-zone-using-ultralytics-yolo.ipynb
+++ b/notebooks/how-to-track-the-objects-in-zone-using-ultralytics-yolo.ipynb
@@ -21,7 +21,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-train-ultralytics-yolo-on-brain-tumor-detection-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-brain-tumor-detection-dataset.ipynb
@@ -22,7 +22,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-train-ultralytics-yolo-on-carparts-segmentation-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-carparts-segmentation-dataset.ipynb
@@ -20,7 +20,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-train-ultralytics-yolo-on-construction-ppe-detection-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-construction-ppe-detection-dataset.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-train-ultralytics-yolo-on-crack-segmentation-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-crack-segmentation-dataset.ipynb
@@ -21,7 +21,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-train-ultralytics-yolo-on-homeobjects-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-homeobjects-dataset.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-train-ultralytics-yolo-on-kitti-detection-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-kitti-detection-dataset.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-train-ultralytics-yolo-on-medical-pills-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-medical-pills-dataset.ipynb
@@ -20,7 +20,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-train-ultralytics-yolo-on-package-segmentation-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-package-segmentation-dataset.ipynb
@@ -21,7 +21,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-use-florence-2-for-object-detection-image-captioning-ocr-and-segmentation.ipynb
+++ b/notebooks/how-to-use-florence-2-for-object-detection-image-captioning-ocr-and-segmentation.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "<div align=\"center\">\n",
     "\n",
-    "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+    "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
     "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
     "\n",
     "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-use-google-gemini-models-for-object-detection-image-captioning-and-ocr.ipynb
+++ b/notebooks/how-to-use-google-gemini-models-for-object-detection-image-captioning-and-ocr.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "<div align=\"center\">\n",
     "\n",
-    "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+    "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
     "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
     "\n",
     "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-use-ultralytics-yolo-with-openai-for-number-plate-recognition.ipynb
+++ b/notebooks/how-to-use-ultralytics-yolo-with-openai-for-number-plate-recognition.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "<div align=\"center\">\n",
     "\n",
-    "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+    "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
     "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
     "\n",
     "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/how-to-use-ultralytics-yolo-with-sahi.ipynb
+++ b/notebooks/how-to-use-ultralytics-yolo-with-sahi.ipynb
@@ -20,7 +20,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",

--- a/notebooks/inference-with-meta-sam-and-sam2-using-ultralytics-python-package.ipynb
+++ b/notebooks/inference-with-meta-sam-and-sam2-using-ultralytics-python-package.ipynb
@@ -20,7 +20,7 @@
       "source": [
         "<div align=\"center\">\n",
         "\n",
-        "  <a href=\"https://ultralytics.com/yolo\" target=\"_blank\">\n",
+        "  <a href=\"https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner\" target=\"_blank\">\n",
         "    <img width=\"1024\", src=\"https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png\"></a>\n",
         "\n",
         "  [中文](https://docs.ultralytics.com/zh/) | [한국어](https://docs.ultralytics.com/ko/) | [日本語](https://docs.ultralytics.com/ja/) | [Русский](https://docs.ultralytics.com/ru/) | [Deutsch](https://docs.ultralytics.com/de/) | [Français](https://docs.ultralytics.com/fr/) | [Español](https://docs.ultralytics.com/es/) | [Português](https://docs.ultralytics.com/pt/) | [Türkçe](https://docs.ultralytics.com/tr/) | [Tiếng Việt](https://docs.ultralytics.com/vi/) | [العربية](https://docs.ultralytics.com/ar/)\n",


### PR DESCRIPTION
The YOLO Vision 2026 "Register now" banner (image swapped in ultralytics/assets#184) is embedded here, but the click still went to the Platform or a generic link. This repoints only the banner's link to the YOLO Vision 2026 event page so the clickable banner matches its call to action.

Only the link wrapping the banner-yolov8 image is changed; all other links are untouched. Banner image is unchanged (swapped in-place via the assets repo).

Deleted: nothing — one-line link corrections; the previous URLs are replaced, nothing to relocate or remove.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated repository and notebook banners to link to the YOLO Vision 2026 event page. 📣

### 📊 Key Changes

- Replaced legacy Ultralytics and Platform banner links in `README.md` and `README.zh-CN.md`.
- Updated banner links across numerous notebooks covering:
  - Object counting, tracking, heatmaps, and queue monitoring.
  - Dataset training and segmentation workflows.
  - Model export and validation results.
  - Florence 2, Gemini, OpenAI, SAHI, SAM, and SAM2 integrations.
- Added consistent YOLO Vision 2026 campaign tracking parameters to all new links.

### 🎯 Purpose & Impact

- 📅 Directs repository visitors and notebook users to the [YOLO Vision 2026 event page](https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner).
- 🔗 Replaces outdated banner destinations with a current, campaign-specific resource.
- 🧭 Improves consistency across English, Chinese, and notebook documentation.
- ⚙️ No functional code, model, or notebook workflow changes are introduced.