### PR TITLE
Ruff 0.16.0 compatibility changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: "0 8 * * *"  # Daily at 08:00 UTC
+    - cron: "0 8 * * *" # Daily at 08:00 UTC
 
 jobs:
   notebook-smoke:


### PR DESCRIPTION
Applies the Prettier change reported by Ultralytics Actions but excluded from its bot commit because workflow files require elevated permissions.

Deleted: the extra spacing before the workflow schedule comment.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧹 Cleans up the CI workflow formatting without changing its behavior.

### 📊 Key Changes

- Removed extra spacing before the inline comment on the daily scheduled CI job in `.github/workflows/ci.yml`.
- Kept the existing daily schedule of 08:00 UTC unchanged.
- No changes were made to the notebook smoke-test job or CI functionality.

### 🎯 Purpose & Impact

- ✅ Improves YAML formatting consistency and readability.
- 🔒 Has no functional impact on scheduled workflows or pull-request checks.
- 🛠️ Helps maintain a cleaner, more consistent CI configuration.