### PR TITLE
Add status badges to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 [中文](README.zh-CN.md) | [한국어](https://docs.ultralytics.com/ko) | [日本語](https://docs.ultralytics.com/ja) | [Русский](https://docs.ultralytics.com/ru) | [Deutsch](https://docs.ultralytics.com/de) | [Français](https://docs.ultralytics.com/fr) | [Español](https://docs.ultralytics.com/es) | [Português](https://docs.ultralytics.com/pt) | [Türkçe](https://docs.ultralytics.com/tr) | [Tiếng Việt](https://docs.ultralytics.com/vi) | [العربية](https://docs.ultralytics.com/ar) <br>
 
+<div>
+    <a href="https://github.com/ultralytics/notebooks/actions/workflows/ci.yml"><img src="https://github.com/ultralytics/notebooks/actions/workflows/ci.yml/badge.svg" alt="Notebook Smoke Tests"></a>
+    <a href="https://github.com/ultralytics/notebooks/actions/workflows/format.yml"><img src="https://github.com/ultralytics/notebooks/actions/workflows/format.yml/badge.svg" alt="Ultralytics Actions"></a>
+    <a href="https://discord.com/invite/ultralytics"><img alt="Ultralytics Discord" src="https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue"></a>
+    <a href="https://community.ultralytics.com/"><img alt="Ultralytics Forums" src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue"></a>
+    <a href="https://www.reddit.com/r/ultralytics/"><img alt="Ultralytics Reddit" src="https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue"></a>
+</div>
+
 <div align="center">
   <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="2%" alt="Ultralytics GitHub"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,14 @@
 
 [中文](README.zh-CN.md) | [한국어](https://docs.ultralytics.com/ko) | [日本語](https://docs.ultralytics.com/ja) | [Русский](https://docs.ultralytics.com/ru) | [Deutsch](https://docs.ultralytics.com/de) | [Français](https://docs.ultralytics.com/fr) | [Español](https://docs.ultralytics.com/es) | [Português](https://docs.ultralytics.com/pt) | [Türkçe](https://docs.ultralytics.com/tr) | [Tiếng Việt](https://docs.ultralytics.com/vi) | [العربية](https://docs.ultralytics.com/ar) <br>
 
+<div>
+    <a href="https://github.com/ultralytics/notebooks/actions/workflows/ci.yml"><img src="https://github.com/ultralytics/notebooks/actions/workflows/ci.yml/badge.svg" alt="Notebook Smoke Tests"></a>
+    <a href="https://github.com/ultralytics/notebooks/actions/workflows/format.yml"><img src="https://github.com/ultralytics/notebooks/actions/workflows/format.yml/badge.svg" alt="Ultralytics Actions"></a>
+    <a href="https://discord.com/invite/ultralytics"><img alt="Ultralytics Discord" src="https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue"></a>
+    <a href="https://community.ultralytics.com/"><img alt="Ultralytics Forums" src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue"></a>
+    <a href="https://www.reddit.com/r/ultralytics/"><img alt="Ultralytics Reddit" src="https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue"></a>
+</div>
+
 <div align="center">
   <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="2%" alt="Ultralytics GitHub"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="2%" alt="space">


### PR DESCRIPTION
Both READMEs opened with the banner, language selector, and social icons but carried no repo badges, so the CI state was not visible from the repo front page.

Added a badge row matching the layout used by `ultralytics/yolo11` and siblings: the repo's own `ci.yml` (Notebook Smoke Tests) and `format.yml` (Ultralytics Actions) workflow badges, plus Discord, Forums, and Reddit. Mirrored in `README.zh-CN.md`. Both workflow badge URLs verified to render.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds CI status and community links to the English and Chinese notebook repository README files. ✅

### 📊 Key Changes

- Added **Notebook Smoke Tests** workflow status badges to both `README.md` and `README.zh-CN.md`.
- Added a badge for the repository’s **formatting checks**.
- Added links and badges for Ultralytics’:
  - [Discord community](https://discord.com/invite/ultralytics)
  - [Community forums](https://community.ultralytics.com/)
  - [Reddit community](https://www.reddit.com/r/ultralytics/)

### 🎯 Purpose & Impact

- Makes automated testing and formatting status visible directly from the repository documentation. 🔍
- Helps users quickly discover Ultralytics support and discussion channels. 💬
- Keeps the English and Chinese README pages consistent while improving project transparency and community engagement. 🌐