### PR TITLE
List Depth in the train task enumerations

### DIFF
--- a/notebooks/how-to-train-ultralytics-yolo-on-brain-tumor-detection-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-brain-tumor-detection-dataset.ipynb
@@ -163,7 +163,7 @@
       "source": [
         "## Train\n",
         "\n",
-        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
+        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Depth](https://docs.ultralytics.com/tasks/depth/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
       ],
       "metadata": {
         "id": "fMV-sNfiSt_X"

--- a/notebooks/how-to-train-ultralytics-yolo-on-carparts-segmentation-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-carparts-segmentation-dataset.ipynb
@@ -171,7 +171,7 @@
       "source": [
         "## Train\n",
         "\n",
-        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
+        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Depth](https://docs.ultralytics.com/tasks/depth/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
       ],
       "metadata": {
         "id": "fMV-sNfiSt_X"

--- a/notebooks/how-to-train-ultralytics-yolo-on-construction-ppe-detection-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-construction-ppe-detection-dataset.ipynb
@@ -164,7 +164,7 @@
       "source": [
         "## Train\n",
         "\n",
-        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
+        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Depth](https://docs.ultralytics.com/tasks/depth/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
       ]
     },
     {

--- a/notebooks/how-to-train-ultralytics-yolo-on-crack-segmentation-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-crack-segmentation-dataset.ipynb
@@ -153,7 +153,7 @@
       "source": [
         "## Train\n",
         "\n",
-        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
+        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Depth](https://docs.ultralytics.com/tasks/depth/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
       ],
       "metadata": {
         "id": "fMV-sNfiSt_X"

--- a/notebooks/how-to-train-ultralytics-yolo-on-homeobjects-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-homeobjects-dataset.ipynb
@@ -150,7 +150,7 @@
       "source": [
         "## Train\n",
         "\n",
-        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
+        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Depth](https://docs.ultralytics.com/tasks/depth/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
       ]
     },
     {

--- a/notebooks/how-to-train-ultralytics-yolo-on-kitti-detection-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-kitti-detection-dataset.ipynb
@@ -160,7 +160,7 @@
       "source": [
         "## Train\n",
         "\n",
-        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
+        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Depth](https://docs.ultralytics.com/tasks/depth/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
       ]
     },
     {

--- a/notebooks/how-to-train-ultralytics-yolo-on-medical-pills-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-medical-pills-dataset.ipynb
@@ -164,7 +164,7 @@
       "source": [
         "## Train\n",
         "\n",
-        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
+        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Depth](https://docs.ultralytics.com/tasks/depth/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
       ],
       "metadata": {
         "id": "fMV-sNfiSt_X"

--- a/notebooks/how-to-train-ultralytics-yolo-on-package-segmentation-dataset.ipynb
+++ b/notebooks/how-to-train-ultralytics-yolo-on-package-segmentation-dataset.ipynb
@@ -150,7 +150,7 @@
       "source": [
         "## Train\n",
         "\n",
-        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
+        "Train YOLO26 on [Detect](https://docs.ultralytics.com/tasks/detect/), [Segment](https://docs.ultralytics.com/tasks/segment/), [Semantic](https://docs.ultralytics.com/tasks/semantic/), [Depth](https://docs.ultralytics.com/tasks/depth/), [Classify](https://docs.ultralytics.com/tasks/classify/), [Pose](https://docs.ultralytics.com/tasks/pose/) and [OBB](https://docs.ultralytics.com/tasks/obb/) datasets. See [YOLO26 Train Docs](https://docs.ultralytics.com/modes/train/) for more information."
       ],
       "metadata": {
         "id": "fMV-sNfiSt_X"


### PR DESCRIPTION
## summary

- eight training notebooks list the trainable tasks as Detect, Segment, Semantic, Classify, Pose and OBB, omitting Depth; this inserts `[Depth]` after `[Semantic]` so each list carries all seven in the canonical `detect, segment, semantic, depth, classify, pose, obb` order
- the remaining eleven notebooks in the repo have no such enumeration and are untouched

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated eight YOLO26 training notebooks to include Depth in their task enumerations, keeping the documented list complete and in canonical order.

### 📊 Key Changes

- Added a linked `[Depth]` task after `[Semantic]` in each affected notebook.
- Updated the enumerations to list Detect, Segment, Semantic, Depth, Classify, Pose, and OBB.
- Left the other eleven notebooks unchanged because they do not contain this task enumeration.

### 🎯 Purpose & Impact

- Notebook readers now see the complete set of seven documented training tasks and can access the Depth task documentation directly.
- No user-facing training behavior changed; these are documentation-only updates.