### PR TITLE
Standardize .github configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# Dependabot for package version updates
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/.github/workflows"
+    schedule:
+      interval: weekly
+      time: "04:00"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
           python: true # Format Python with Ruff and docformatter
           prettier: true # Format YAML, JSON, Markdown, CSS
           spelling: true # Check spelling with codespell
-          links: false # Check broken links with Lychee
+          links: true # Check broken links with Lychee
           summary: true # Generate AI-powered PR summaries
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution


### PR DESCRIPTION
Aligns \`.github/\` with the reference configuration used in \`ultralytics/sdk\`, \`skills\`, \`openapi\` and \`lite\`.

- Add \`dependabot.yml\` for the version-pinned \`actions/checkout@v7\` and \`actions/setup-python@v7\` used by \`ci.yml\` and \`table.yml\`.
- \`format.yml\`: enable the Lychee broken-link check, as in the reference repositories.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Standardized GitHub configuration by adding weekly Dependabot updates for GitHub Actions and enabling Lychee broken-link checks in the formatting workflow.

### 📊 Key Changes

- Added `.github/dependabot.yml` to monitor GitHub Actions in `.github/workflows`.
- Configured Dependabot to run weekly, open up to five pull requests, and apply the `dependencies` label.
- Enabled `links: true` in `format.yml`, activating Lychee link validation.

### 🎯 Purpose & Impact

- GitHub Actions dependencies can now receive scheduled Dependabot update pull requests.
- The formatting workflow now checks for broken links.
- No other workflow behavior was changed.